### PR TITLE
Updating the package version to 12.2 to match the PulseAudio sources

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,7 +41,7 @@
     <Company>TerraFX</Company>
     <PackageOutputPath>$(BaseArtifactsPath)pkg/$(Configuration)/</PackageOutputPath>
     <Product>TerraFX.Interop.PulseAudio</Product>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>12.2.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <VersionSuffix Condition="'$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)' != ''">pr$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)</VersionSuffix>
   </PropertyGroup>


### PR DESCRIPTION
This updates the version to 12.2 to match the PulseAudio source version that bindings were generated from.