### PR TITLE
Adding the ability for users to hook the DllImportResolver

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -19,8 +19,8 @@
 
   <!-- Package versions for package references across all projects -->
   <ItemGroup>
-    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="3.4.0" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="3.5.0-beta1-final" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0-preview-20191115-01" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <PackageReference Update="NUnit" Version="3.12.0" />
     <PackageReference Update="NUnit3TestAdapter" Version="3.15.1" />

--- a/sources/Interop/PulseAudio/NativeTypeNameAttribute.cs
+++ b/sources/Interop/PulseAudio/NativeTypeNameAttribute.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 namespace TerraFX.Interop
 {
     /// <summary>Defines the type of a member as it was used in the native signature.</summary>
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.ReturnValue, AllowMultiple = false, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Enum | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.ReturnValue, AllowMultiple = false, Inherited = true)]
     [Conditional("DEBUG")]
     internal sealed class NativeTypeNameAttribute : Attribute
     {

--- a/sources/Interop/PulseAudio/Pulse.cs
+++ b/sources/Interop/PulseAudio/Pulse.cs
@@ -8,21 +8,71 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        private const string libraryPath = "libpulse";
+        private const string LibraryPath = "libpulse";
+
+        public static event DllImportResolver? ResolveLibrary;
 
         static Pulse()
         {
-            NativeLibrary.SetDllImportResolver(Assembly.GetExecutingAssembly(), ResolveLibrary);
+            NativeLibrary.SetDllImportResolver(Assembly.GetExecutingAssembly(), OnDllImport);
         }
 
-        private static IntPtr ResolveLibrary(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+        private static IntPtr OnDllImport(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
         {
-            if (!NativeLibrary.TryLoad("libpulse.so", assembly, searchPath, out var nativeLibrary))
+            IntPtr nativeLibrary;
+
+            if (TryResolveLibrary(libraryName, assembly, searchPath, out nativeLibrary))
             {
-                nativeLibrary = NativeLibrary.Load("libpulse.so.0", assembly, searchPath);
+                return nativeLibrary;
             }
 
-            return nativeLibrary;
+            if (libraryName.Equals("libpulse") && TryResolveLibPulse(assembly, searchPath, out nativeLibrary))
+            {
+                return nativeLibrary;
+            }
+
+            return IntPtr.Zero;
+        }
+
+        private static bool TryResolveLibPulse(Assembly assembly, DllImportSearchPath? searchPath, out IntPtr nativeLibrary)
+        {
+            if (NativeLibrary.TryLoad("libpulse", assembly, searchPath, out nativeLibrary))
+            {
+                return true;
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                if (NativeLibrary.TryLoad("libpulse.so.0", assembly, searchPath, out nativeLibrary))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool TryResolveLibrary(string libraryName, Assembly assembly, DllImportSearchPath? searchPath, out IntPtr nativeLibrary)
+        {
+            var resolveLibrary = ResolveLibrary;
+
+            if (resolveLibrary != null)
+            {
+                var resolvers = resolveLibrary.GetInvocationList();
+
+                foreach (DllImportResolver resolver in resolvers)
+                {
+                    nativeLibrary = resolver(libraryName, assembly, searchPath);
+
+                    if (nativeLibrary != IntPtr.Zero)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            nativeLibrary = IntPtr.Zero;
+            return false;
         }
     }
 }

--- a/sources/Interop/PulseAudio/channelmap/Pulse.cs
+++ b/sources/Interop/PulseAudio/channelmap/Pulse.cs
@@ -10,79 +10,79 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_channel_map_init", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channel_map_init", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_channel_map *")]
         public static extern pa_channel_map* pa_channel_map_init([NativeTypeName("pa_channel_map *")] pa_channel_map* m);
 
-        [DllImport(libraryPath, EntryPoint = "pa_channel_map_init_mono", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channel_map_init_mono", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_channel_map *")]
         public static extern pa_channel_map* pa_channel_map_init_mono([NativeTypeName("pa_channel_map *")] pa_channel_map* m);
 
-        [DllImport(libraryPath, EntryPoint = "pa_channel_map_init_stereo", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channel_map_init_stereo", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_channel_map *")]
         public static extern pa_channel_map* pa_channel_map_init_stereo([NativeTypeName("pa_channel_map *")] pa_channel_map* m);
 
-        [DllImport(libraryPath, EntryPoint = "pa_channel_map_init_auto", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channel_map_init_auto", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_channel_map *")]
         public static extern pa_channel_map* pa_channel_map_init_auto([NativeTypeName("pa_channel_map *")] pa_channel_map* m, [NativeTypeName("unsigned int")] uint channels, [NativeTypeName("pa_channel_map_def_t")] pa_channel_map_def def);
 
-        [DllImport(libraryPath, EntryPoint = "pa_channel_map_init_extend", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channel_map_init_extend", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_channel_map *")]
         public static extern pa_channel_map* pa_channel_map_init_extend([NativeTypeName("pa_channel_map *")] pa_channel_map* m, [NativeTypeName("unsigned int")] uint channels, [NativeTypeName("pa_channel_map_def_t")] pa_channel_map_def def);
 
-        [DllImport(libraryPath, EntryPoint = "pa_channel_position_to_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channel_position_to_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const char *")]
         public static extern sbyte* pa_channel_position_to_string([NativeTypeName("pa_channel_position_t")] pa_channel_position pos);
 
-        [DllImport(libraryPath, EntryPoint = "pa_channel_position_from_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channel_position_from_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_channel_position_t")]
         public static extern pa_channel_position pa_channel_position_from_string([NativeTypeName("const char *")] sbyte* s);
 
-        [DllImport(libraryPath, EntryPoint = "pa_channel_position_to_pretty_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channel_position_to_pretty_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const char *")]
         public static extern sbyte* pa_channel_position_to_pretty_string([NativeTypeName("pa_channel_position_t")] pa_channel_position pos);
 
-        [DllImport(libraryPath, EntryPoint = "pa_channel_map_snprint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channel_map_snprint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_channel_map_snprint([NativeTypeName("char *")] sbyte* s, [NativeTypeName("size_t")] UIntPtr l, [NativeTypeName("const pa_channel_map *")] pa_channel_map* map);
 
-        [DllImport(libraryPath, EntryPoint = "pa_channel_map_parse", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channel_map_parse", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_channel_map *")]
         public static extern pa_channel_map* pa_channel_map_parse([NativeTypeName("pa_channel_map *")] pa_channel_map* map, [NativeTypeName("const char *")] sbyte* s);
 
-        [DllImport(libraryPath, EntryPoint = "pa_channel_map_equal", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channel_map_equal", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_channel_map_equal([NativeTypeName("const pa_channel_map *")] pa_channel_map* a, [NativeTypeName("const pa_channel_map *")] pa_channel_map* b);
 
-        [DllImport(libraryPath, EntryPoint = "pa_channel_map_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channel_map_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_channel_map_valid([NativeTypeName("const pa_channel_map *")] pa_channel_map* map);
 
-        [DllImport(libraryPath, EntryPoint = "pa_channel_map_compatible", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channel_map_compatible", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_channel_map_compatible([NativeTypeName("const pa_channel_map *")] pa_channel_map* map, [NativeTypeName("const pa_sample_spec *")] pa_sample_spec* ss);
 
-        [DllImport(libraryPath, EntryPoint = "pa_channel_map_superset", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channel_map_superset", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_channel_map_superset([NativeTypeName("const pa_channel_map *")] pa_channel_map* a, [NativeTypeName("const pa_channel_map *")] pa_channel_map* b);
 
-        [DllImport(libraryPath, EntryPoint = "pa_channel_map_can_balance", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channel_map_can_balance", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_channel_map_can_balance([NativeTypeName("const pa_channel_map *")] pa_channel_map* map);
 
-        [DllImport(libraryPath, EntryPoint = "pa_channel_map_can_fade", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channel_map_can_fade", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_channel_map_can_fade([NativeTypeName("const pa_channel_map *")] pa_channel_map* map);
 
-        [DllImport(libraryPath, EntryPoint = "pa_channel_map_can_lfe_balance", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channel_map_can_lfe_balance", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_channel_map_can_lfe_balance([NativeTypeName("const pa_channel_map *")] pa_channel_map* map);
 
-        [DllImport(libraryPath, EntryPoint = "pa_channel_map_to_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channel_map_to_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const char *")]
         public static extern sbyte* pa_channel_map_to_name([NativeTypeName("const pa_channel_map *")] pa_channel_map* map);
 
-        [DllImport(libraryPath, EntryPoint = "pa_channel_map_to_pretty_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channel_map_to_pretty_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const char *")]
         public static extern sbyte* pa_channel_map_to_pretty_name([NativeTypeName("const pa_channel_map *")] pa_channel_map* map);
 
-        [DllImport(libraryPath, EntryPoint = "pa_channel_map_has_position", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channel_map_has_position", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_channel_map_has_position([NativeTypeName("const pa_channel_map *")] pa_channel_map* map, [NativeTypeName("pa_channel_position_t")] pa_channel_position p);
 
-        [DllImport(libraryPath, EntryPoint = "pa_channel_map_mask", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channel_map_mask", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_channel_position_mask_t")]
         public static extern UIntPtr pa_channel_map_mask([NativeTypeName("const pa_channel_map *")] pa_channel_map* map);
     }

--- a/sources/Interop/PulseAudio/context/Pulse.cs
+++ b/sources/Interop/PulseAudio/context/Pulse.cs
@@ -10,102 +10,102 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_context_new", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_new", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_context *")]
         public static extern pa_context* pa_context_new([NativeTypeName("pa_mainloop_api *")] pa_mainloop_api* mainloop, [NativeTypeName("const char *")] sbyte* name);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_new_with_proplist", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_new_with_proplist", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_context *")]
         public static extern pa_context* pa_context_new_with_proplist([NativeTypeName("pa_mainloop_api *")] pa_mainloop_api* mainloop, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("pa_proplist *")] pa_proplist* proplist);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_unref", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_unref", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_context_unref([NativeTypeName("pa_context *")] pa_context* c);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_ref", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_ref", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_context *")]
         public static extern pa_context* pa_context_ref([NativeTypeName("pa_context *")] pa_context* c);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_state_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_state_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_context_set_state_callback([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_context_notify_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_event_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_event_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_context_set_event_callback([NativeTypeName("pa_context *")] pa_context* p, [NativeTypeName("pa_context_event_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_errno", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_errno", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_context_errno([NativeTypeName("pa_context *")] pa_context* c);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_is_pending", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_is_pending", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_context_is_pending([NativeTypeName("pa_context *")] pa_context* c);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_state", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_state", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_context_state_t")]
         public static extern pa_context_state pa_context_get_state([NativeTypeName("pa_context *")] pa_context* c);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_connect", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_connect", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_context_connect([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* server, [NativeTypeName("pa_context_flags_t")] pa_context_flags flags, [NativeTypeName("const pa_spawn_api *")] pa_spawn_api* api);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_disconnect", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_disconnect", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_context_disconnect([NativeTypeName("pa_context *")] pa_context* c);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_drain", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_drain", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_drain([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_context_notify_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_exit_daemon", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_exit_daemon", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_exit_daemon([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_default_sink", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_default_sink", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_default_sink([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_default_source", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_default_source", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_default_source([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_is_local", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_is_local", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_context_is_local([NativeTypeName("pa_context *")] pa_context* c);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_name([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_server", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_server", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const char *")]
         public static extern sbyte* pa_context_get_server([NativeTypeName("pa_context *")] pa_context* c);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_protocol_version", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_protocol_version", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("uint32_t")]
         public static extern uint pa_context_get_protocol_version([NativeTypeName("pa_context *")] pa_context* c);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_server_protocol_version", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_server_protocol_version", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("uint32_t")]
         public static extern uint pa_context_get_server_protocol_version([NativeTypeName("pa_context *")] pa_context* c);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_proplist_update", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_proplist_update", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_proplist_update([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_update_mode_t")] pa_update_mode mode, [NativeTypeName("pa_proplist *")] pa_proplist* p, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_proplist_remove", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_proplist_remove", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_proplist_remove([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *const []")] sbyte* keys, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("uint32_t")]
         public static extern uint pa_context_get_index([NativeTypeName("pa_context *")] pa_context* s);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_rttime_new", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_rttime_new", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_time_event *")]
         public static extern pa_time_event* pa_context_rttime_new([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_usec_t")] UIntPtr usec, [NativeTypeName("pa_time_event_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_rttime_restart", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_rttime_restart", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_context_rttime_restart([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_time_event *")] pa_time_event* e, [NativeTypeName("pa_usec_t")] UIntPtr usec);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_tile_size", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_tile_size", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("size_t")]
         public static extern UIntPtr pa_context_get_tile_size([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const pa_sample_spec *")] pa_sample_spec* ss);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_load_cookie_from_file", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_load_cookie_from_file", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_context_load_cookie_from_file([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* cookie_file_path);
     }
 }

--- a/sources/Interop/PulseAudio/direction/Pulse.cs
+++ b/sources/Interop/PulseAudio/direction/Pulse.cs
@@ -9,10 +9,10 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_direction_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_direction_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_direction_valid([NativeTypeName("pa_direction_t")] pa_direction direction);
 
-        [DllImport(libraryPath, EntryPoint = "pa_direction_to_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_direction_to_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const char *")]
         public static extern sbyte* pa_direction_to_string([NativeTypeName("pa_direction_t")] pa_direction direction);
     }

--- a/sources/Interop/PulseAudio/error/Pulse.cs
+++ b/sources/Interop/PulseAudio/error/Pulse.cs
@@ -9,7 +9,7 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_strerror", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_strerror", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const char *")]
         public static extern sbyte* pa_strerror(int error);
     }

--- a/sources/Interop/PulseAudio/ext-device-manager/Pulse.cs
+++ b/sources/Interop/PulseAudio/ext-device-manager/Pulse.cs
@@ -10,35 +10,35 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_ext_device_manager_test", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ext_device_manager_test", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_ext_device_manager_test([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_ext_device_manager_test_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_ext_device_manager_read", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ext_device_manager_read", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_ext_device_manager_read([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_ext_device_manager_read_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_ext_device_manager_set_device_description", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ext_device_manager_set_device_description", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_ext_device_manager_set_device_description([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* device, [NativeTypeName("const char *")] sbyte* description, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_ext_device_manager_delete", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ext_device_manager_delete", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_ext_device_manager_delete([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *const []")] sbyte* s, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_ext_device_manager_enable_role_device_priority_routing", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ext_device_manager_enable_role_device_priority_routing", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_ext_device_manager_enable_role_device_priority_routing([NativeTypeName("pa_context *")] pa_context* c, int enable, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_ext_device_manager_reorder_devices_for_role", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ext_device_manager_reorder_devices_for_role", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_ext_device_manager_reorder_devices_for_role([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* role, [NativeTypeName("const char **")] sbyte** devices, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_ext_device_manager_subscribe", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ext_device_manager_subscribe", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_ext_device_manager_subscribe([NativeTypeName("pa_context *")] pa_context* c, int enable, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_ext_device_manager_set_subscribe_cb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ext_device_manager_set_subscribe_cb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_ext_device_manager_set_subscribe_cb([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_ext_device_manager_subscribe_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
     }
 }

--- a/sources/Interop/PulseAudio/ext-device-restore/Pulse.cs
+++ b/sources/Interop/PulseAudio/ext-device-restore/Pulse.cs
@@ -10,26 +10,26 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_ext_device_restore_test", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ext_device_restore_test", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_ext_device_restore_test([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_ext_device_restore_test_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_ext_device_restore_subscribe", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ext_device_restore_subscribe", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_ext_device_restore_subscribe([NativeTypeName("pa_context *")] pa_context* c, int enable, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_ext_device_restore_set_subscribe_cb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ext_device_restore_set_subscribe_cb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_ext_device_restore_set_subscribe_cb([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_ext_device_restore_subscribe_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_ext_device_restore_read_formats_all", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ext_device_restore_read_formats_all", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_ext_device_restore_read_formats_all([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_ext_device_restore_read_device_formats_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_ext_device_restore_read_formats", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ext_device_restore_read_formats", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_ext_device_restore_read_formats([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_device_type_t")] pa_device_type type, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("pa_ext_device_restore_read_device_formats_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_ext_device_restore_save_formats", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ext_device_restore_save_formats", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_ext_device_restore_save_formats([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_device_type_t")] pa_device_type type, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("uint8_t")] byte n_formats, [NativeTypeName("pa_format_info **")] pa_format_info** formats, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
     }

--- a/sources/Interop/PulseAudio/ext-stream-restore/Pulse.cs
+++ b/sources/Interop/PulseAudio/ext-stream-restore/Pulse.cs
@@ -10,27 +10,27 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_ext_stream_restore_test", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ext_stream_restore_test", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_ext_stream_restore_test([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_ext_stream_restore_test_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_ext_stream_restore_read", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ext_stream_restore_read", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_ext_stream_restore_read([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_ext_stream_restore_read_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_ext_stream_restore_write", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ext_stream_restore_write", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_ext_stream_restore_write([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_update_mode_t")] pa_update_mode mode, [NativeTypeName("const pa_ext_stream_restore_info []")] pa_ext_stream_restore_info data, [NativeTypeName("unsigned int")] uint n, int apply_immediately, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_ext_stream_restore_delete", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ext_stream_restore_delete", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_ext_stream_restore_delete([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *const []")] sbyte* s, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_ext_stream_restore_subscribe", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ext_stream_restore_subscribe", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_ext_stream_restore_subscribe([NativeTypeName("pa_context *")] pa_context* c, int enable, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_ext_stream_restore_set_subscribe_cb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ext_stream_restore_set_subscribe_cb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_ext_stream_restore_set_subscribe_cb([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_ext_stream_restore_subscribe_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
     }
 }

--- a/sources/Interop/PulseAudio/format/Pulse.cs
+++ b/sources/Interop/PulseAudio/format/Pulse.cs
@@ -10,95 +10,95 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_encoding_to_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_encoding_to_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const char *")]
         public static extern sbyte* pa_encoding_to_string([NativeTypeName("pa_encoding_t")] pa_encoding e);
 
-        [DllImport(libraryPath, EntryPoint = "pa_encoding_from_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_encoding_from_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_encoding_t")]
         public static extern pa_encoding pa_encoding_from_string([NativeTypeName("const char *")] sbyte* encoding);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_new", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_new", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_format_info *")]
         public static extern pa_format_info* pa_format_info_new();
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_copy", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_copy", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_format_info *")]
         public static extern pa_format_info* pa_format_info_copy([NativeTypeName("const pa_format_info *")] pa_format_info* src);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_free", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_free", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_format_info_free([NativeTypeName("pa_format_info *")] pa_format_info* f);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_format_info_valid([NativeTypeName("const pa_format_info *")] pa_format_info* f);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_is_pcm", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_is_pcm", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_format_info_is_pcm([NativeTypeName("const pa_format_info *")] pa_format_info* f);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_is_compatible", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_is_compatible", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_format_info_is_compatible([NativeTypeName("const pa_format_info *")] pa_format_info* first, [NativeTypeName("const pa_format_info *")] pa_format_info* second);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_snprint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_snprint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_format_info_snprint([NativeTypeName("char *")] sbyte* s, [NativeTypeName("size_t")] UIntPtr l, [NativeTypeName("const pa_format_info *")] pa_format_info* f);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_from_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_from_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_format_info *")]
         public static extern pa_format_info* pa_format_info_from_string([NativeTypeName("const char *")] sbyte* str);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_from_sample_spec", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_from_sample_spec", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_format_info *")]
         public static extern pa_format_info* pa_format_info_from_sample_spec([NativeTypeName("const pa_sample_spec *")] pa_sample_spec* ss, [NativeTypeName("const pa_channel_map *")] pa_channel_map* map);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_to_sample_spec", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_to_sample_spec", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_format_info_to_sample_spec([NativeTypeName("const pa_format_info *")] pa_format_info* f, [NativeTypeName("pa_sample_spec *")] pa_sample_spec* ss, [NativeTypeName("pa_channel_map *")] pa_channel_map* map);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_get_prop_type", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_get_prop_type", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern pa_prop_type_t pa_format_info_get_prop_type([NativeTypeName("const pa_format_info *")] pa_format_info* f, [NativeTypeName("const char *")] sbyte* key);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_get_prop_int", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_get_prop_int", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_format_info_get_prop_int([NativeTypeName("const pa_format_info *")] pa_format_info* f, [NativeTypeName("const char *")] sbyte* key, [NativeTypeName("int *")] int* v);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_get_prop_int_range", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_get_prop_int_range", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_format_info_get_prop_int_range([NativeTypeName("const pa_format_info *")] pa_format_info* f, [NativeTypeName("const char *")] sbyte* key, [NativeTypeName("int *")] int* min, [NativeTypeName("int *")] int* max);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_get_prop_int_array", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_get_prop_int_array", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_format_info_get_prop_int_array([NativeTypeName("const pa_format_info *")] pa_format_info* f, [NativeTypeName("const char *")] sbyte* key, [NativeTypeName("int **")] int** values, [NativeTypeName("int *")] int* n_values);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_get_prop_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_get_prop_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_format_info_get_prop_string([NativeTypeName("const pa_format_info *")] pa_format_info* f, [NativeTypeName("const char *")] sbyte* key, [NativeTypeName("char **")] sbyte** v);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_get_prop_string_array", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_get_prop_string_array", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_format_info_get_prop_string_array([NativeTypeName("const pa_format_info *")] pa_format_info* f, [NativeTypeName("const char *")] sbyte* key, [NativeTypeName("char ***")] sbyte*** values, [NativeTypeName("int *")] int* n_values);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_free_string_array", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_free_string_array", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_format_info_free_string_array([NativeTypeName("char **")] sbyte** values, int n_values);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_set_prop_int", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_set_prop_int", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_format_info_set_prop_int([NativeTypeName("pa_format_info *")] pa_format_info* f, [NativeTypeName("const char *")] sbyte* key, int value);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_set_prop_int_array", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_set_prop_int_array", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_format_info_set_prop_int_array([NativeTypeName("pa_format_info *")] pa_format_info* f, [NativeTypeName("const char *")] sbyte* key, [NativeTypeName("const int *")] int* values, int n_values);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_set_prop_int_range", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_set_prop_int_range", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_format_info_set_prop_int_range([NativeTypeName("pa_format_info *")] pa_format_info* f, [NativeTypeName("const char *")] sbyte* key, int min, int max);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_set_prop_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_set_prop_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_format_info_set_prop_string([NativeTypeName("pa_format_info *")] pa_format_info* f, [NativeTypeName("const char *")] sbyte* key, [NativeTypeName("const char *")] sbyte* value);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_set_prop_string_array", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_set_prop_string_array", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_format_info_set_prop_string_array([NativeTypeName("pa_format_info *")] pa_format_info* f, [NativeTypeName("const char *")] sbyte* key, [NativeTypeName("const char **")] sbyte** values, int n_values);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_set_sample_format", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_set_sample_format", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_format_info_set_sample_format([NativeTypeName("pa_format_info *")] pa_format_info* f, [NativeTypeName("pa_sample_format_t")] pa_sample_format sf);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_set_rate", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_set_rate", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_format_info_set_rate([NativeTypeName("pa_format_info *")] pa_format_info* f, int rate);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_set_channels", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_set_channels", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_format_info_set_channels([NativeTypeName("pa_format_info *")] pa_format_info* f, int channels);
 
-        [DllImport(libraryPath, EntryPoint = "pa_format_info_set_channel_map", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_format_info_set_channel_map", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_format_info_set_channel_map([NativeTypeName("pa_format_info *")] pa_format_info* f, [NativeTypeName("const pa_channel_map *")] pa_channel_map* map);
     }
 }

--- a/sources/Interop/PulseAudio/introspect/Pulse.cs
+++ b/sources/Interop/PulseAudio/introspect/Pulse.cs
@@ -10,243 +10,243 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_sink_info_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_sink_info_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_sink_info_by_name([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("pa_sink_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_sink_info_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_sink_info_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_sink_info_by_index([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("pa_sink_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_sink_info_list", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_sink_info_list", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_sink_info_list([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_sink_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_sink_volume_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_sink_volume_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_sink_volume_by_index([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("const pa_cvolume *")] pa_cvolume* volume, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_sink_volume_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_sink_volume_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_sink_volume_by_name([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("const pa_cvolume *")] pa_cvolume* volume, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_sink_mute_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_sink_mute_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_sink_mute_by_index([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, int mute, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_sink_mute_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_sink_mute_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_sink_mute_by_name([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, int mute, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_suspend_sink_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_suspend_sink_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_suspend_sink_by_name([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* sink_name, int suspend, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_suspend_sink_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_suspend_sink_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_suspend_sink_by_index([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, int suspend, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_sink_port_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_sink_port_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_sink_port_by_index([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("const char *")] sbyte* port, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_sink_port_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_sink_port_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_sink_port_by_name([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("const char *")] sbyte* port, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_source_info_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_source_info_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_source_info_by_name([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("pa_source_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_source_info_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_source_info_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_source_info_by_index([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("pa_source_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_source_info_list", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_source_info_list", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_source_info_list([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_source_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_source_volume_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_source_volume_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_source_volume_by_index([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("const pa_cvolume *")] pa_cvolume* volume, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_source_volume_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_source_volume_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_source_volume_by_name([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("const pa_cvolume *")] pa_cvolume* volume, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_source_mute_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_source_mute_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_source_mute_by_index([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, int mute, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_source_mute_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_source_mute_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_source_mute_by_name([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, int mute, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_suspend_source_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_suspend_source_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_suspend_source_by_name([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* source_name, int suspend, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_suspend_source_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_suspend_source_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_suspend_source_by_index([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, int suspend, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_source_port_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_source_port_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_source_port_by_index([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("const char *")] sbyte* port, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_source_port_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_source_port_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_source_port_by_name([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("const char *")] sbyte* port, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_server_info", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_server_info", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_server_info([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_server_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_module_info", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_module_info", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_module_info([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("pa_module_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_module_info_list", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_module_info_list", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_module_info_list([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_module_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_load_module", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_load_module", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_load_module([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("const char *")] sbyte* argument, [NativeTypeName("pa_context_index_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_unload_module", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_unload_module", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_unload_module([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_client_info", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_client_info", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_client_info([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("pa_client_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_client_info_list", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_client_info_list", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_client_info_list([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_client_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_kill_client", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_kill_client", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_kill_client([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_card_info_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_card_info_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_card_info_by_index([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("pa_card_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_card_info_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_card_info_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_card_info_by_name([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("pa_card_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_card_info_list", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_card_info_list", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_card_info_list([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_card_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_card_profile_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_card_profile_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_card_profile_by_index([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("const char *")] sbyte* profile, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_card_profile_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_card_profile_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_card_profile_by_name([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("const char *")] sbyte* profile, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_port_latency_offset", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_port_latency_offset", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_port_latency_offset([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* card_name, [NativeTypeName("const char *")] sbyte* port_name, [NativeTypeName("int64_t")] IntPtr offset, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_sink_input_info", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_sink_input_info", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_sink_input_info([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("pa_sink_input_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_sink_input_info_list", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_sink_input_info_list", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_sink_input_info_list([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_sink_input_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_move_sink_input_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_move_sink_input_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_move_sink_input_by_name([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("const char *")] sbyte* sink_name, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_move_sink_input_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_move_sink_input_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_move_sink_input_by_index([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("uint32_t")] uint sink_idx, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_sink_input_volume", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_sink_input_volume", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_sink_input_volume([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("const pa_cvolume *")] pa_cvolume* volume, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_sink_input_mute", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_sink_input_mute", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_sink_input_mute([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, int mute, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_kill_sink_input", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_kill_sink_input", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_kill_sink_input([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_source_output_info", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_source_output_info", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_source_output_info([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("pa_source_output_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_source_output_info_list", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_source_output_info_list", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_source_output_info_list([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_source_output_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_move_source_output_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_move_source_output_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_move_source_output_by_name([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("const char *")] sbyte* source_name, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_move_source_output_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_move_source_output_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_move_source_output_by_index([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("uint32_t")] uint source_idx, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_source_output_volume", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_source_output_volume", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_source_output_volume([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("const pa_cvolume *")] pa_cvolume* volume, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_source_output_mute", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_source_output_mute", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_set_source_output_mute([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, int mute, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_kill_source_output", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_kill_source_output", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_kill_source_output([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_stat", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_stat", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_stat([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_stat_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_sample_info_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_sample_info_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_sample_info_by_name([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("pa_sample_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_sample_info_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_sample_info_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_sample_info_by_index([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("pa_sample_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_sample_info_list", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_sample_info_list", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_sample_info_list([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_sample_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_autoload_info_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_autoload_info_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_autoload_info_by_name([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("pa_autoload_type_t")] pa_autoload_type type, [NativeTypeName("pa_autoload_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_autoload_info_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_autoload_info_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_autoload_info_by_index([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("pa_autoload_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_get_autoload_info_list", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_get_autoload_info_list", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_get_autoload_info_list([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_autoload_info_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_add_autoload", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_add_autoload", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_add_autoload([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("pa_autoload_type_t")] pa_autoload_type type, [NativeTypeName("const char *")] sbyte* module, [NativeTypeName("const char *")] sbyte* argument, [NativeTypeName("pa_context_index_cb_t")] IntPtr param5, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_remove_autoload_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_remove_autoload_by_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_remove_autoload_by_name([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("pa_autoload_type_t")] pa_autoload_type type, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_remove_autoload_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_remove_autoload_by_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_remove_autoload_by_index([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("uint32_t")] uint idx, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
     }

--- a/sources/Interop/PulseAudio/mainloop-api/Pulse.cs
+++ b/sources/Interop/PulseAudio/mainloop-api/Pulse.cs
@@ -10,7 +10,7 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_mainloop_api_once", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_mainloop_api_once", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_mainloop_api_once([NativeTypeName("pa_mainloop_api *")] pa_mainloop_api* m, [NativeTypeName("void (*)(pa_mainloop_api *, void *)")] IntPtr callback, [NativeTypeName("void *")] void* userdata);
     }
 }

--- a/sources/Interop/PulseAudio/mainloop-signal/Pulse.cs
+++ b/sources/Interop/PulseAudio/mainloop-signal/Pulse.cs
@@ -10,20 +10,20 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_signal_init", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_signal_init", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_signal_init([NativeTypeName("pa_mainloop_api *")] pa_mainloop_api* api);
 
-        [DllImport(libraryPath, EntryPoint = "pa_signal_done", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_signal_done", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_signal_done();
 
-        [DllImport(libraryPath, EntryPoint = "pa_signal_new", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_signal_new", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_signal_event *")]
         public static extern pa_signal_event* pa_signal_new(int sig, [NativeTypeName("pa_signal_cb_t")] IntPtr callback, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_signal_free", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_signal_free", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_signal_free([NativeTypeName("pa_signal_event *")] pa_signal_event* e);
 
-        [DllImport(libraryPath, EntryPoint = "pa_signal_set_destroy", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_signal_set_destroy", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_signal_set_destroy([NativeTypeName("pa_signal_event *")] pa_signal_event* e, [NativeTypeName("pa_signal_destroy_cb_t")] IntPtr callback);
     }
 }

--- a/sources/Interop/PulseAudio/mainloop/Pulse.cs
+++ b/sources/Interop/PulseAudio/mainloop/Pulse.cs
@@ -10,42 +10,42 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_mainloop_new", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_mainloop_new", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_mainloop *")]
         public static extern pa_mainloop* pa_mainloop_new();
 
-        [DllImport(libraryPath, EntryPoint = "pa_mainloop_free", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_mainloop_free", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_mainloop_free([NativeTypeName("pa_mainloop *")] pa_mainloop* m);
 
-        [DllImport(libraryPath, EntryPoint = "pa_mainloop_prepare", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_mainloop_prepare", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_mainloop_prepare([NativeTypeName("pa_mainloop *")] pa_mainloop* m, int timeout);
 
-        [DllImport(libraryPath, EntryPoint = "pa_mainloop_poll", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_mainloop_poll", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_mainloop_poll([NativeTypeName("pa_mainloop *")] pa_mainloop* m);
 
-        [DllImport(libraryPath, EntryPoint = "pa_mainloop_dispatch", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_mainloop_dispatch", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_mainloop_dispatch([NativeTypeName("pa_mainloop *")] pa_mainloop* m);
 
-        [DllImport(libraryPath, EntryPoint = "pa_mainloop_get_retval", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_mainloop_get_retval", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_mainloop_get_retval([NativeTypeName("pa_mainloop *")] pa_mainloop* m);
 
-        [DllImport(libraryPath, EntryPoint = "pa_mainloop_iterate", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_mainloop_iterate", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_mainloop_iterate([NativeTypeName("pa_mainloop *")] pa_mainloop* m, int block, [NativeTypeName("int *")] int* retval);
 
-        [DllImport(libraryPath, EntryPoint = "pa_mainloop_run", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_mainloop_run", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_mainloop_run([NativeTypeName("pa_mainloop *")] pa_mainloop* m, [NativeTypeName("int *")] int* retval);
 
-        [DllImport(libraryPath, EntryPoint = "pa_mainloop_get_api", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_mainloop_get_api", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_mainloop_api *")]
         public static extern pa_mainloop_api* pa_mainloop_get_api([NativeTypeName("pa_mainloop *")] pa_mainloop* m);
 
-        [DllImport(libraryPath, EntryPoint = "pa_mainloop_quit", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_mainloop_quit", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_mainloop_quit([NativeTypeName("pa_mainloop *")] pa_mainloop* m, int retval);
 
-        [DllImport(libraryPath, EntryPoint = "pa_mainloop_wakeup", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_mainloop_wakeup", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_mainloop_wakeup([NativeTypeName("pa_mainloop *")] pa_mainloop* m);
 
-        [DllImport(libraryPath, EntryPoint = "pa_mainloop_set_poll_func", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_mainloop_set_poll_func", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_mainloop_set_poll_func([NativeTypeName("pa_mainloop *")] pa_mainloop* m, [NativeTypeName("pa_poll_func")] IntPtr poll_func, [NativeTypeName("void *")] void* userdata);
     }
 }

--- a/sources/Interop/PulseAudio/operation/Pulse.cs
+++ b/sources/Interop/PulseAudio/operation/Pulse.cs
@@ -10,21 +10,21 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_operation_ref", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_operation_ref", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_operation_ref([NativeTypeName("pa_operation *")] pa_operation* o);
 
-        [DllImport(libraryPath, EntryPoint = "pa_operation_unref", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_operation_unref", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_operation_unref([NativeTypeName("pa_operation *")] pa_operation* o);
 
-        [DllImport(libraryPath, EntryPoint = "pa_operation_cancel", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_operation_cancel", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_operation_cancel([NativeTypeName("pa_operation *")] pa_operation* o);
 
-        [DllImport(libraryPath, EntryPoint = "pa_operation_get_state", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_operation_get_state", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation_state_t")]
         public static extern pa_operation_state pa_operation_get_state([NativeTypeName("pa_operation *")] pa_operation* o);
 
-        [DllImport(libraryPath, EntryPoint = "pa_operation_set_state_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_operation_set_state_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_operation_set_state_callback([NativeTypeName("pa_operation *")] pa_operation* o, [NativeTypeName("pa_operation_notify_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
     }
 }

--- a/sources/Interop/PulseAudio/proplist/Pulse.cs
+++ b/sources/Interop/PulseAudio/proplist/Pulse.cs
@@ -10,78 +10,78 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_new", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_new", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_proplist *")]
         public static extern pa_proplist* pa_proplist_new();
 
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_free", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_free", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_proplist_free([NativeTypeName("pa_proplist *")] pa_proplist* p);
 
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_key_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_key_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_proplist_key_valid([NativeTypeName("const char *")] sbyte* key);
 
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_sets", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_sets", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_proplist_sets([NativeTypeName("pa_proplist *")] pa_proplist* p, [NativeTypeName("const char *")] sbyte* key, [NativeTypeName("const char *")] sbyte* value);
 
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_setp", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_setp", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_proplist_setp([NativeTypeName("pa_proplist *")] pa_proplist* p, [NativeTypeName("const char *")] sbyte* pair);
 
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_setf", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_setf", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_proplist_setf([NativeTypeName("pa_proplist *")] pa_proplist* p, [NativeTypeName("const char *")] sbyte* key, [NativeTypeName("const char *")] sbyte* format);
 
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_set", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_set", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_proplist_set([NativeTypeName("pa_proplist *")] pa_proplist* p, [NativeTypeName("const char *")] sbyte* key, [NativeTypeName("const void *")] void* data, [NativeTypeName("size_t")] UIntPtr nbytes);
 
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_gets", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_gets", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const char *")]
         public static extern sbyte* pa_proplist_gets([NativeTypeName("pa_proplist *")] pa_proplist* p, [NativeTypeName("const char *")] sbyte* key);
 
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_get", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_get", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_proplist_get([NativeTypeName("pa_proplist *")] pa_proplist* p, [NativeTypeName("const char *")] sbyte* key, [NativeTypeName("const void **")] void** data, [NativeTypeName("size_t *")] UIntPtr* nbytes);
 
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_update", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_update", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_proplist_update([NativeTypeName("pa_proplist *")] pa_proplist* p, [NativeTypeName("pa_update_mode_t")] pa_update_mode mode, [NativeTypeName("const pa_proplist *")] pa_proplist* other);
 
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_unset", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_unset", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_proplist_unset([NativeTypeName("pa_proplist *")] pa_proplist* p, [NativeTypeName("const char *")] sbyte* key);
 
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_unset_many", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_unset_many", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_proplist_unset_many([NativeTypeName("pa_proplist *")] pa_proplist* p, [NativeTypeName("const char *const []")] sbyte* keys);
 
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_iterate", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_iterate", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const char *")]
         public static extern sbyte* pa_proplist_iterate([NativeTypeName("pa_proplist *")] pa_proplist* p, [NativeTypeName("void **")] void** state);
 
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_to_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_to_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_proplist_to_string([NativeTypeName("pa_proplist *")] pa_proplist* p);
 
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_to_string_sep", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_to_string_sep", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_proplist_to_string_sep([NativeTypeName("pa_proplist *")] pa_proplist* p, [NativeTypeName("const char *")] sbyte* sep);
 
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_from_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_from_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_proplist *")]
         public static extern pa_proplist* pa_proplist_from_string([NativeTypeName("const char *")] sbyte* str);
 
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_contains", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_contains", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_proplist_contains([NativeTypeName("pa_proplist *")] pa_proplist* p, [NativeTypeName("const char *")] sbyte* key);
 
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_clear", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_clear", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_proplist_clear([NativeTypeName("pa_proplist *")] pa_proplist* p);
 
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_copy", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_copy", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_proplist *")]
         public static extern pa_proplist* pa_proplist_copy([NativeTypeName("const pa_proplist *")] pa_proplist* p);
 
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_size", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_size", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("unsigned int")]
         public static extern uint pa_proplist_size([NativeTypeName("pa_proplist *")] pa_proplist* p);
 
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_isempty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_isempty", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_proplist_isempty([NativeTypeName("pa_proplist *")] pa_proplist* p);
 
-        [DllImport(libraryPath, EntryPoint = "pa_proplist_equal", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_proplist_equal", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_proplist_equal([NativeTypeName("pa_proplist *")] pa_proplist* a, [NativeTypeName("pa_proplist *")] pa_proplist* b);
     }
 }

--- a/sources/Interop/PulseAudio/rtclock/Pulse.cs
+++ b/sources/Interop/PulseAudio/rtclock/Pulse.cs
@@ -10,7 +10,7 @@ namespace TerraFX.Interop
 {
     public static partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_rtclock_now", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_rtclock_now", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_usec_t")]
         public static extern UIntPtr pa_rtclock_now();
     }

--- a/sources/Interop/PulseAudio/sample/Pulse.cs
+++ b/sources/Interop/PulseAudio/sample/Pulse.cs
@@ -10,69 +10,69 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_bytes_per_second", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_bytes_per_second", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("size_t")]
         public static extern UIntPtr pa_bytes_per_second([NativeTypeName("const pa_sample_spec *")] pa_sample_spec* spec);
 
-        [DllImport(libraryPath, EntryPoint = "pa_frame_size", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_frame_size", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("size_t")]
         public static extern UIntPtr pa_frame_size([NativeTypeName("const pa_sample_spec *")] pa_sample_spec* spec);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sample_size", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sample_size", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("size_t")]
         public static extern UIntPtr pa_sample_size([NativeTypeName("const pa_sample_spec *")] pa_sample_spec* spec);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sample_size_of_format", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sample_size_of_format", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("size_t")]
         public static extern UIntPtr pa_sample_size_of_format([NativeTypeName("pa_sample_format_t")] pa_sample_format f);
 
-        [DllImport(libraryPath, EntryPoint = "pa_bytes_to_usec", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_bytes_to_usec", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_usec_t")]
         public static extern UIntPtr pa_bytes_to_usec([NativeTypeName("uint64_t")] UIntPtr length, [NativeTypeName("const pa_sample_spec *")] pa_sample_spec* spec);
 
-        [DllImport(libraryPath, EntryPoint = "pa_usec_to_bytes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_usec_to_bytes", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("size_t")]
         public static extern UIntPtr pa_usec_to_bytes([NativeTypeName("pa_usec_t")] UIntPtr t, [NativeTypeName("const pa_sample_spec *")] pa_sample_spec* spec);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sample_spec_init", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sample_spec_init", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_sample_spec *")]
         public static extern pa_sample_spec* pa_sample_spec_init([NativeTypeName("pa_sample_spec *")] pa_sample_spec* spec);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sample_format_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sample_format_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_sample_format_valid([NativeTypeName("unsigned int")] uint format);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sample_rate_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sample_rate_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_sample_rate_valid([NativeTypeName("uint32_t")] uint rate);
 
-        [DllImport(libraryPath, EntryPoint = "pa_channels_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_channels_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_channels_valid([NativeTypeName("uint8_t")] byte channels);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sample_spec_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sample_spec_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_sample_spec_valid([NativeTypeName("const pa_sample_spec *")] pa_sample_spec* spec);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sample_spec_equal", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sample_spec_equal", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_sample_spec_equal([NativeTypeName("const pa_sample_spec *")] pa_sample_spec* a, [NativeTypeName("const pa_sample_spec *")] pa_sample_spec* b);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sample_format_to_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sample_format_to_string", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const char *")]
         public static extern sbyte* pa_sample_format_to_string([NativeTypeName("pa_sample_format_t")] pa_sample_format f);
 
-        [DllImport(libraryPath, EntryPoint = "pa_parse_sample_format", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_parse_sample_format", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_sample_format_t")]
         public static extern pa_sample_format pa_parse_sample_format([NativeTypeName("const char *")] sbyte* format);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sample_spec_snprint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sample_spec_snprint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_sample_spec_snprint([NativeTypeName("char *")] sbyte* s, [NativeTypeName("size_t")] UIntPtr l, [NativeTypeName("const pa_sample_spec *")] pa_sample_spec* spec);
 
-        [DllImport(libraryPath, EntryPoint = "pa_bytes_snprint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_bytes_snprint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_bytes_snprint([NativeTypeName("char *")] sbyte* s, [NativeTypeName("size_t")] UIntPtr l, [NativeTypeName("unsigned int")] uint v);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sample_format_is_le", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sample_format_is_le", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_sample_format_is_le([NativeTypeName("pa_sample_format_t")] pa_sample_format f);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sample_format_is_be", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sample_format_is_be", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_sample_format_is_be([NativeTypeName("pa_sample_format_t")] pa_sample_format f);
     }
 }

--- a/sources/Interop/PulseAudio/scache/Pulse.cs
+++ b/sources/Interop/PulseAudio/scache/Pulse.cs
@@ -10,21 +10,21 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_stream_connect_upload", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_connect_upload", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_stream_connect_upload([NativeTypeName("pa_stream *")] pa_stream* s, [NativeTypeName("size_t")] UIntPtr length);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_finish_upload", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_finish_upload", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_stream_finish_upload([NativeTypeName("pa_stream *")] pa_stream* s);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_remove_sample", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_remove_sample", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_remove_sample([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_play_sample", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_play_sample", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_play_sample([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("const char *")] sbyte* dev, [NativeTypeName("pa_volume_t")] uint volume, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_play_sample_with_proplist", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_play_sample_with_proplist", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_play_sample_with_proplist([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("const char *")] sbyte* dev, [NativeTypeName("pa_volume_t")] uint volume, [NativeTypeName("pa_proplist *")] pa_proplist* proplist, [NativeTypeName("pa_context_play_sample_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
     }

--- a/sources/Interop/PulseAudio/simple/Pulse.cs
+++ b/sources/Interop/PulseAudio/simple/Pulse.cs
@@ -10,27 +10,27 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_simple_new", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_simple_new", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_simple *")]
         public static extern pa_simple* pa_simple_new([NativeTypeName("const char *")] sbyte* server, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("pa_stream_direction_t")] pa_stream_direction dir, [NativeTypeName("const char *")] sbyte* dev, [NativeTypeName("const char *")] sbyte* stream_name, [NativeTypeName("const pa_sample_spec *")] pa_sample_spec* ss, [NativeTypeName("const pa_channel_map *")] pa_channel_map* map, [NativeTypeName("const pa_buffer_attr *")] pa_buffer_attr* attr, [NativeTypeName("int *")] int* error);
 
-        [DllImport(libraryPath, EntryPoint = "pa_simple_free", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_simple_free", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_simple_free([NativeTypeName("pa_simple *")] pa_simple* s);
 
-        [DllImport(libraryPath, EntryPoint = "pa_simple_write", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_simple_write", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_simple_write([NativeTypeName("pa_simple *")] pa_simple* s, [NativeTypeName("const void *")] void* data, [NativeTypeName("size_t")] UIntPtr bytes, [NativeTypeName("int *")] int* error);
 
-        [DllImport(libraryPath, EntryPoint = "pa_simple_drain", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_simple_drain", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_simple_drain([NativeTypeName("pa_simple *")] pa_simple* s, [NativeTypeName("int *")] int* error);
 
-        [DllImport(libraryPath, EntryPoint = "pa_simple_read", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_simple_read", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_simple_read([NativeTypeName("pa_simple *")] pa_simple* s, [NativeTypeName("void *")] void* data, [NativeTypeName("size_t")] UIntPtr bytes, [NativeTypeName("int *")] int* error);
 
-        [DllImport(libraryPath, EntryPoint = "pa_simple_get_latency", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_simple_get_latency", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_usec_t")]
         public static extern UIntPtr pa_simple_get_latency([NativeTypeName("pa_simple *")] pa_simple* s, [NativeTypeName("int *")] int* error);
 
-        [DllImport(libraryPath, EntryPoint = "pa_simple_flush", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_simple_flush", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_simple_flush([NativeTypeName("pa_simple *")] pa_simple* s, [NativeTypeName("int *")] int* error);
     }
 }

--- a/sources/Interop/PulseAudio/stream/Pulse.cs
+++ b/sources/Interop/PulseAudio/stream/Pulse.cs
@@ -10,197 +10,197 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_stream_new", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_new", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_stream *")]
         public static extern pa_stream* pa_stream_new([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("const pa_sample_spec *")] pa_sample_spec* ss, [NativeTypeName("const pa_channel_map *")] pa_channel_map* map);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_new_with_proplist", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_new_with_proplist", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_stream *")]
         public static extern pa_stream* pa_stream_new_with_proplist([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("const pa_sample_spec *")] pa_sample_spec* ss, [NativeTypeName("const pa_channel_map *")] pa_channel_map* map, [NativeTypeName("pa_proplist *")] pa_proplist* p);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_new_extended", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_new_extended", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_stream *")]
         public static extern pa_stream* pa_stream_new_extended([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("pa_format_info *const *")] pa_format_info** formats, [NativeTypeName("unsigned int")] uint n_formats, [NativeTypeName("pa_proplist *")] pa_proplist* p);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_unref", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_unref", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_stream_unref([NativeTypeName("pa_stream *")] pa_stream* s);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_ref", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_ref", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_stream *")]
         public static extern pa_stream* pa_stream_ref([NativeTypeName("pa_stream *")] pa_stream* s);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_get_state", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_get_state", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_stream_state_t")]
         public static extern pa_stream_state pa_stream_get_state([NativeTypeName("pa_stream *")] pa_stream* p);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_get_context", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_get_context", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_context *")]
         public static extern pa_context* pa_stream_get_context([NativeTypeName("pa_stream *")] pa_stream* p);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_get_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_get_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("uint32_t")]
         public static extern uint pa_stream_get_index([NativeTypeName("pa_stream *")] pa_stream* s);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_get_device_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_get_device_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("uint32_t")]
         public static extern uint pa_stream_get_device_index([NativeTypeName("pa_stream *")] pa_stream* s);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_get_device_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_get_device_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const char *")]
         public static extern sbyte* pa_stream_get_device_name([NativeTypeName("pa_stream *")] pa_stream* s);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_is_suspended", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_is_suspended", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_stream_is_suspended([NativeTypeName("pa_stream *")] pa_stream* s);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_is_corked", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_is_corked", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_stream_is_corked([NativeTypeName("pa_stream *")] pa_stream* s);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_connect_playback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_connect_playback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_stream_connect_playback([NativeTypeName("pa_stream *")] pa_stream* s, [NativeTypeName("const char *")] sbyte* dev, [NativeTypeName("const pa_buffer_attr *")] pa_buffer_attr* attr, [NativeTypeName("pa_stream_flags_t")] pa_stream_flags flags, [NativeTypeName("const pa_cvolume *")] pa_cvolume* volume, [NativeTypeName("pa_stream *")] pa_stream* sync_stream);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_connect_record", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_connect_record", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_stream_connect_record([NativeTypeName("pa_stream *")] pa_stream* s, [NativeTypeName("const char *")] sbyte* dev, [NativeTypeName("const pa_buffer_attr *")] pa_buffer_attr* attr, [NativeTypeName("pa_stream_flags_t")] pa_stream_flags flags);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_disconnect", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_disconnect", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_stream_disconnect([NativeTypeName("pa_stream *")] pa_stream* s);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_begin_write", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_begin_write", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_stream_begin_write([NativeTypeName("pa_stream *")] pa_stream* p, [NativeTypeName("void **")] void** data, [NativeTypeName("size_t *")] UIntPtr* nbytes);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_cancel_write", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_cancel_write", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_stream_cancel_write([NativeTypeName("pa_stream *")] pa_stream* p);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_write", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_write", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_stream_write([NativeTypeName("pa_stream *")] pa_stream* p, [NativeTypeName("const void *")] void* data, [NativeTypeName("size_t")] UIntPtr nbytes, [NativeTypeName("pa_free_cb_t")] IntPtr free_cb, [NativeTypeName("int64_t")] IntPtr offset, [NativeTypeName("pa_seek_mode_t")] pa_seek_mode seek);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_write_ext_free", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_write_ext_free", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_stream_write_ext_free([NativeTypeName("pa_stream *")] pa_stream* p, [NativeTypeName("const void *")] void* data, [NativeTypeName("size_t")] UIntPtr nbytes, [NativeTypeName("pa_free_cb_t")] IntPtr free_cb, [NativeTypeName("void *")] void* free_cb_data, [NativeTypeName("int64_t")] IntPtr offset, [NativeTypeName("pa_seek_mode_t")] pa_seek_mode seek);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_peek", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_peek", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_stream_peek([NativeTypeName("pa_stream *")] pa_stream* p, [NativeTypeName("const void **")] void** data, [NativeTypeName("size_t *")] UIntPtr* nbytes);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_drop", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_drop", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_stream_drop([NativeTypeName("pa_stream *")] pa_stream* p);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_writable_size", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_writable_size", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("size_t")]
         public static extern UIntPtr pa_stream_writable_size([NativeTypeName("pa_stream *")] pa_stream* p);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_readable_size", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_readable_size", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("size_t")]
         public static extern UIntPtr pa_stream_readable_size([NativeTypeName("pa_stream *")] pa_stream* p);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_drain", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_drain", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_stream_drain([NativeTypeName("pa_stream *")] pa_stream* s, [NativeTypeName("pa_stream_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_update_timing_info", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_update_timing_info", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_stream_update_timing_info([NativeTypeName("pa_stream *")] pa_stream* p, [NativeTypeName("pa_stream_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_set_state_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_set_state_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_stream_set_state_callback([NativeTypeName("pa_stream *")] pa_stream* s, [NativeTypeName("pa_stream_notify_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_set_write_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_set_write_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_stream_set_write_callback([NativeTypeName("pa_stream *")] pa_stream* p, [NativeTypeName("pa_stream_request_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_set_read_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_set_read_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_stream_set_read_callback([NativeTypeName("pa_stream *")] pa_stream* p, [NativeTypeName("pa_stream_request_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_set_overflow_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_set_overflow_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_stream_set_overflow_callback([NativeTypeName("pa_stream *")] pa_stream* p, [NativeTypeName("pa_stream_notify_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_get_underflow_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_get_underflow_index", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int64_t")]
         public static extern IntPtr pa_stream_get_underflow_index([NativeTypeName("pa_stream *")] pa_stream* p);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_set_underflow_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_set_underflow_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_stream_set_underflow_callback([NativeTypeName("pa_stream *")] pa_stream* p, [NativeTypeName("pa_stream_notify_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_set_started_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_set_started_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_stream_set_started_callback([NativeTypeName("pa_stream *")] pa_stream* p, [NativeTypeName("pa_stream_notify_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_set_latency_update_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_set_latency_update_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_stream_set_latency_update_callback([NativeTypeName("pa_stream *")] pa_stream* p, [NativeTypeName("pa_stream_notify_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_set_moved_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_set_moved_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_stream_set_moved_callback([NativeTypeName("pa_stream *")] pa_stream* p, [NativeTypeName("pa_stream_notify_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_set_suspended_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_set_suspended_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_stream_set_suspended_callback([NativeTypeName("pa_stream *")] pa_stream* p, [NativeTypeName("pa_stream_notify_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_set_event_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_set_event_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_stream_set_event_callback([NativeTypeName("pa_stream *")] pa_stream* p, [NativeTypeName("pa_stream_event_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_set_buffer_attr_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_set_buffer_attr_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_stream_set_buffer_attr_callback([NativeTypeName("pa_stream *")] pa_stream* p, [NativeTypeName("pa_stream_notify_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_cork", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_cork", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_stream_cork([NativeTypeName("pa_stream *")] pa_stream* s, int b, [NativeTypeName("pa_stream_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_flush", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_flush", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_stream_flush([NativeTypeName("pa_stream *")] pa_stream* s, [NativeTypeName("pa_stream_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_prebuf", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_prebuf", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_stream_prebuf([NativeTypeName("pa_stream *")] pa_stream* s, [NativeTypeName("pa_stream_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_trigger", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_trigger", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_stream_trigger([NativeTypeName("pa_stream *")] pa_stream* s, [NativeTypeName("pa_stream_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_set_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_set_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_stream_set_name([NativeTypeName("pa_stream *")] pa_stream* s, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("pa_stream_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_get_time", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_get_time", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_stream_get_time([NativeTypeName("pa_stream *")] pa_stream* s, [NativeTypeName("pa_usec_t *")] UIntPtr* r_usec);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_get_latency", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_get_latency", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_stream_get_latency([NativeTypeName("pa_stream *")] pa_stream* s, [NativeTypeName("pa_usec_t *")] UIntPtr* r_usec, [NativeTypeName("int *")] int* negative);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_get_timing_info", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_get_timing_info", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const pa_timing_info *")]
         public static extern pa_timing_info* pa_stream_get_timing_info([NativeTypeName("pa_stream *")] pa_stream* s);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_get_sample_spec", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_get_sample_spec", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const pa_sample_spec *")]
         public static extern pa_sample_spec* pa_stream_get_sample_spec([NativeTypeName("pa_stream *")] pa_stream* s);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_get_channel_map", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_get_channel_map", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const pa_channel_map *")]
         public static extern pa_channel_map* pa_stream_get_channel_map([NativeTypeName("pa_stream *")] pa_stream* s);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_get_format_info", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_get_format_info", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const pa_format_info *")]
         public static extern pa_format_info* pa_stream_get_format_info([NativeTypeName("pa_stream *")] pa_stream* s);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_get_buffer_attr", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_get_buffer_attr", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const pa_buffer_attr *")]
         public static extern pa_buffer_attr* pa_stream_get_buffer_attr([NativeTypeName("pa_stream *")] pa_stream* s);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_set_buffer_attr", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_set_buffer_attr", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_stream_set_buffer_attr([NativeTypeName("pa_stream *")] pa_stream* s, [NativeTypeName("const pa_buffer_attr *")] pa_buffer_attr* attr, [NativeTypeName("pa_stream_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_update_sample_rate", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_update_sample_rate", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_stream_update_sample_rate([NativeTypeName("pa_stream *")] pa_stream* s, [NativeTypeName("uint32_t")] uint rate, [NativeTypeName("pa_stream_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_proplist_update", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_proplist_update", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_stream_proplist_update([NativeTypeName("pa_stream *")] pa_stream* s, [NativeTypeName("pa_update_mode_t")] pa_update_mode mode, [NativeTypeName("pa_proplist *")] pa_proplist* p, [NativeTypeName("pa_stream_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_proplist_remove", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_proplist_remove", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_stream_proplist_remove([NativeTypeName("pa_stream *")] pa_stream* s, [NativeTypeName("const char *const []")] sbyte* keys, [NativeTypeName("pa_stream_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_set_monitor_stream", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_set_monitor_stream", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_stream_set_monitor_stream([NativeTypeName("pa_stream *")] pa_stream* s, [NativeTypeName("uint32_t")] uint sink_input_idx);
 
-        [DllImport(libraryPath, EntryPoint = "pa_stream_get_monitor_stream", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_stream_get_monitor_stream", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("uint32_t")]
         public static extern uint pa_stream_get_monitor_stream([NativeTypeName("pa_stream *")] pa_stream* s);
     }

--- a/sources/Interop/PulseAudio/subscribe/Pulse.cs
+++ b/sources/Interop/PulseAudio/subscribe/Pulse.cs
@@ -10,11 +10,11 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_context_subscribe", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_subscribe", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_operation *")]
         public static extern pa_operation* pa_context_subscribe([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_subscription_mask_t")] pa_subscription_mask m, [NativeTypeName("pa_context_success_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
 
-        [DllImport(libraryPath, EntryPoint = "pa_context_set_subscribe_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_context_set_subscribe_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_context_set_subscribe_callback([NativeTypeName("pa_context *")] pa_context* c, [NativeTypeName("pa_context_subscribe_cb_t")] IntPtr cb, [NativeTypeName("void *")] void* userdata);
     }
 }

--- a/sources/Interop/PulseAudio/thread-mainloop/Pulse.cs
+++ b/sources/Interop/PulseAudio/thread-mainloop/Pulse.cs
@@ -9,45 +9,45 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_threaded_mainloop_new", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_threaded_mainloop_new", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_threaded_mainloop *")]
         public static extern pa_threaded_mainloop* pa_threaded_mainloop_new();
 
-        [DllImport(libraryPath, EntryPoint = "pa_threaded_mainloop_free", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_threaded_mainloop_free", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_threaded_mainloop_free([NativeTypeName("pa_threaded_mainloop *")] pa_threaded_mainloop* m);
 
-        [DllImport(libraryPath, EntryPoint = "pa_threaded_mainloop_start", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_threaded_mainloop_start", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_threaded_mainloop_start([NativeTypeName("pa_threaded_mainloop *")] pa_threaded_mainloop* m);
 
-        [DllImport(libraryPath, EntryPoint = "pa_threaded_mainloop_stop", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_threaded_mainloop_stop", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_threaded_mainloop_stop([NativeTypeName("pa_threaded_mainloop *")] pa_threaded_mainloop* m);
 
-        [DllImport(libraryPath, EntryPoint = "pa_threaded_mainloop_lock", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_threaded_mainloop_lock", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_threaded_mainloop_lock([NativeTypeName("pa_threaded_mainloop *")] pa_threaded_mainloop* m);
 
-        [DllImport(libraryPath, EntryPoint = "pa_threaded_mainloop_unlock", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_threaded_mainloop_unlock", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_threaded_mainloop_unlock([NativeTypeName("pa_threaded_mainloop *")] pa_threaded_mainloop* m);
 
-        [DllImport(libraryPath, EntryPoint = "pa_threaded_mainloop_wait", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_threaded_mainloop_wait", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_threaded_mainloop_wait([NativeTypeName("pa_threaded_mainloop *")] pa_threaded_mainloop* m);
 
-        [DllImport(libraryPath, EntryPoint = "pa_threaded_mainloop_signal", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_threaded_mainloop_signal", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_threaded_mainloop_signal([NativeTypeName("pa_threaded_mainloop *")] pa_threaded_mainloop* m, int wait_for_accept);
 
-        [DllImport(libraryPath, EntryPoint = "pa_threaded_mainloop_accept", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_threaded_mainloop_accept", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_threaded_mainloop_accept([NativeTypeName("pa_threaded_mainloop *")] pa_threaded_mainloop* m);
 
-        [DllImport(libraryPath, EntryPoint = "pa_threaded_mainloop_get_retval", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_threaded_mainloop_get_retval", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_threaded_mainloop_get_retval([NativeTypeName("pa_threaded_mainloop *")] pa_threaded_mainloop* m);
 
-        [DllImport(libraryPath, EntryPoint = "pa_threaded_mainloop_get_api", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_threaded_mainloop_get_api", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_mainloop_api *")]
         public static extern pa_mainloop_api* pa_threaded_mainloop_get_api([NativeTypeName("pa_threaded_mainloop *")] pa_threaded_mainloop* m);
 
-        [DllImport(libraryPath, EntryPoint = "pa_threaded_mainloop_in_thread", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_threaded_mainloop_in_thread", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_threaded_mainloop_in_thread([NativeTypeName("pa_threaded_mainloop *")] pa_threaded_mainloop* m);
 
-        [DllImport(libraryPath, EntryPoint = "pa_threaded_mainloop_set_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_threaded_mainloop_set_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void pa_threaded_mainloop_set_name([NativeTypeName("pa_threaded_mainloop *")] pa_threaded_mainloop* m, [NativeTypeName("const char *")] sbyte* name);
     }
 }

--- a/sources/Interop/PulseAudio/timeval/Pulse.cs
+++ b/sources/Interop/PulseAudio/timeval/Pulse.cs
@@ -10,34 +10,34 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_gettimeofday", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_gettimeofday", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct timeval *")]
         public static extern timeval* pa_gettimeofday([NativeTypeName("struct timeval *")] timeval* tv);
 
-        [DllImport(libraryPath, EntryPoint = "pa_timeval_diff", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_timeval_diff", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_usec_t")]
         public static extern UIntPtr pa_timeval_diff([NativeTypeName("const struct timeval *")] timeval* a, [NativeTypeName("const struct timeval *")] timeval* b);
 
-        [DllImport(libraryPath, EntryPoint = "pa_timeval_cmp", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_timeval_cmp", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_timeval_cmp([NativeTypeName("const struct timeval *")] timeval* a, [NativeTypeName("const struct timeval *")] timeval* b);
 
-        [DllImport(libraryPath, EntryPoint = "pa_timeval_age", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_timeval_age", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_usec_t")]
         public static extern UIntPtr pa_timeval_age([NativeTypeName("const struct timeval *")] timeval* tv);
 
-        [DllImport(libraryPath, EntryPoint = "pa_timeval_add", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_timeval_add", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct timeval *")]
         public static extern timeval* pa_timeval_add([NativeTypeName("struct timeval *")] timeval* tv, [NativeTypeName("pa_usec_t")] UIntPtr v);
 
-        [DllImport(libraryPath, EntryPoint = "pa_timeval_sub", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_timeval_sub", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct timeval *")]
         public static extern timeval* pa_timeval_sub([NativeTypeName("struct timeval *")] timeval* tv, [NativeTypeName("pa_usec_t")] UIntPtr v);
 
-        [DllImport(libraryPath, EntryPoint = "pa_timeval_store", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_timeval_store", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("struct timeval *")]
         public static extern timeval* pa_timeval_store([NativeTypeName("struct timeval *")] timeval* tv, [NativeTypeName("pa_usec_t")] UIntPtr v);
 
-        [DllImport(libraryPath, EntryPoint = "pa_timeval_load", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_timeval_load", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_usec_t")]
         public static extern UIntPtr pa_timeval_load([NativeTypeName("const struct timeval *")] timeval* tv);
     }

--- a/sources/Interop/PulseAudio/utf8/Pulse.cs
+++ b/sources/Interop/PulseAudio/utf8/Pulse.cs
@@ -9,27 +9,27 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_utf8_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_utf8_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_utf8_valid([NativeTypeName("const char *")] sbyte* str);
 
-        [DllImport(libraryPath, EntryPoint = "pa_ascii_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ascii_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_ascii_valid([NativeTypeName("const char *")] sbyte* str);
 
-        [DllImport(libraryPath, EntryPoint = "pa_utf8_filter", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_utf8_filter", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_utf8_filter([NativeTypeName("const char *")] sbyte* str);
 
-        [DllImport(libraryPath, EntryPoint = "pa_ascii_filter", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_ascii_filter", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_ascii_filter([NativeTypeName("const char *")] sbyte* str);
 
-        [DllImport(libraryPath, EntryPoint = "pa_utf8_to_locale", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_utf8_to_locale", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_utf8_to_locale([NativeTypeName("const char *")] sbyte* str);
 
-        [DllImport(libraryPath, EntryPoint = "pa_locale_to_utf8", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_locale_to_utf8", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_locale_to_utf8([NativeTypeName("const char *")] sbyte* str);
     }

--- a/sources/Interop/PulseAudio/util/Pulse.cs
+++ b/sources/Interop/PulseAudio/util/Pulse.cs
@@ -10,31 +10,31 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_get_user_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_get_user_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_get_user_name([NativeTypeName("char *")] sbyte* s, [NativeTypeName("size_t")] UIntPtr l);
 
-        [DllImport(libraryPath, EntryPoint = "pa_get_host_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_get_host_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_get_host_name([NativeTypeName("char *")] sbyte* s, [NativeTypeName("size_t")] UIntPtr l);
 
-        [DllImport(libraryPath, EntryPoint = "pa_get_fqdn", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_get_fqdn", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_get_fqdn([NativeTypeName("char *")] sbyte* s, [NativeTypeName("size_t")] UIntPtr l);
 
-        [DllImport(libraryPath, EntryPoint = "pa_get_home_dir", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_get_home_dir", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_get_home_dir([NativeTypeName("char *")] sbyte* s, [NativeTypeName("size_t")] UIntPtr l);
 
-        [DllImport(libraryPath, EntryPoint = "pa_get_binary_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_get_binary_name", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_get_binary_name([NativeTypeName("char *")] sbyte* s, [NativeTypeName("size_t")] UIntPtr l);
 
-        [DllImport(libraryPath, EntryPoint = "pa_path_get_filename", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_path_get_filename", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_path_get_filename([NativeTypeName("const char *")] sbyte* p);
 
-        [DllImport(libraryPath, EntryPoint = "pa_msleep", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_msleep", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_msleep([NativeTypeName("unsigned long")] UIntPtr t);
     }
 }

--- a/sources/Interop/PulseAudio/version/Pulse.cs
+++ b/sources/Interop/PulseAudio/version/Pulse.cs
@@ -9,7 +9,7 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_get_library_version", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_get_library_version", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const char *")]
         public static extern sbyte* pa_get_library_version();
     }

--- a/sources/Interop/PulseAudio/volume/Pulse.cs
+++ b/sources/Interop/PulseAudio/volume/Pulse.cs
@@ -10,169 +10,169 @@ namespace TerraFX.Interop
 {
     public static unsafe partial class Pulse
     {
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_equal", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_equal", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_cvolume_equal([NativeTypeName("const pa_cvolume *")] pa_cvolume* a, [NativeTypeName("const pa_cvolume *")] pa_cvolume* b);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_init", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_init", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_cvolume *")]
         public static extern pa_cvolume* pa_cvolume_init([NativeTypeName("pa_cvolume *")] pa_cvolume* a);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_set", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_set", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_cvolume *")]
         public static extern pa_cvolume* pa_cvolume_set([NativeTypeName("pa_cvolume *")] pa_cvolume* a, [NativeTypeName("unsigned int")] uint channels, [NativeTypeName("pa_volume_t")] uint v);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_snprint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_snprint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_cvolume_snprint([NativeTypeName("char *")] sbyte* s, [NativeTypeName("size_t")] UIntPtr l, [NativeTypeName("const pa_cvolume *")] pa_cvolume* c);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sw_cvolume_snprint_dB", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sw_cvolume_snprint_dB", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_sw_cvolume_snprint_dB([NativeTypeName("char *")] sbyte* s, [NativeTypeName("size_t")] UIntPtr l, [NativeTypeName("const pa_cvolume *")] pa_cvolume* c);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_snprint_verbose", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_snprint_verbose", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_cvolume_snprint_verbose([NativeTypeName("char *")] sbyte* s, [NativeTypeName("size_t")] UIntPtr l, [NativeTypeName("const pa_cvolume *")] pa_cvolume* c, [NativeTypeName("const pa_channel_map *")] pa_channel_map* map, int print_dB);
 
-        [DllImport(libraryPath, EntryPoint = "pa_volume_snprint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_volume_snprint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_volume_snprint([NativeTypeName("char *")] sbyte* s, [NativeTypeName("size_t")] UIntPtr l, [NativeTypeName("pa_volume_t")] uint v);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sw_volume_snprint_dB", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sw_volume_snprint_dB", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_sw_volume_snprint_dB([NativeTypeName("char *")] sbyte* s, [NativeTypeName("size_t")] UIntPtr l, [NativeTypeName("pa_volume_t")] uint v);
 
-        [DllImport(libraryPath, EntryPoint = "pa_volume_snprint_verbose", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_volume_snprint_verbose", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern sbyte* pa_volume_snprint_verbose([NativeTypeName("char *")] sbyte* s, [NativeTypeName("size_t")] UIntPtr l, [NativeTypeName("pa_volume_t")] uint v, int print_dB);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_avg", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_avg", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_volume_t")]
         public static extern uint pa_cvolume_avg([NativeTypeName("const pa_cvolume *")] pa_cvolume* a);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_avg_mask", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_avg_mask", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_volume_t")]
         public static extern uint pa_cvolume_avg_mask([NativeTypeName("const pa_cvolume *")] pa_cvolume* a, [NativeTypeName("const pa_channel_map *")] pa_channel_map* cm, [NativeTypeName("pa_channel_position_mask_t")] UIntPtr mask);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_max", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_max", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_volume_t")]
         public static extern uint pa_cvolume_max([NativeTypeName("const pa_cvolume *")] pa_cvolume* a);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_max_mask", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_max_mask", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_volume_t")]
         public static extern uint pa_cvolume_max_mask([NativeTypeName("const pa_cvolume *")] pa_cvolume* a, [NativeTypeName("const pa_channel_map *")] pa_channel_map* cm, [NativeTypeName("pa_channel_position_mask_t")] UIntPtr mask);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_min", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_min", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_volume_t")]
         public static extern uint pa_cvolume_min([NativeTypeName("const pa_cvolume *")] pa_cvolume* a);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_min_mask", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_min_mask", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_volume_t")]
         public static extern uint pa_cvolume_min_mask([NativeTypeName("const pa_cvolume *")] pa_cvolume* a, [NativeTypeName("const pa_channel_map *")] pa_channel_map* cm, [NativeTypeName("pa_channel_position_mask_t")] UIntPtr mask);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_valid", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_cvolume_valid([NativeTypeName("const pa_cvolume *")] pa_cvolume* v);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_channels_equal_to", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_channels_equal_to", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_cvolume_channels_equal_to([NativeTypeName("const pa_cvolume *")] pa_cvolume* a, [NativeTypeName("pa_volume_t")] uint v);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sw_volume_multiply", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sw_volume_multiply", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_volume_t")]
         public static extern uint pa_sw_volume_multiply([NativeTypeName("pa_volume_t")] uint a, [NativeTypeName("pa_volume_t")] uint b);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sw_cvolume_multiply", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sw_cvolume_multiply", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_cvolume *")]
         public static extern pa_cvolume* pa_sw_cvolume_multiply([NativeTypeName("pa_cvolume *")] pa_cvolume* dest, [NativeTypeName("const pa_cvolume *")] pa_cvolume* a, [NativeTypeName("const pa_cvolume *")] pa_cvolume* b);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sw_cvolume_multiply_scalar", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sw_cvolume_multiply_scalar", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_cvolume *")]
         public static extern pa_cvolume* pa_sw_cvolume_multiply_scalar([NativeTypeName("pa_cvolume *")] pa_cvolume* dest, [NativeTypeName("const pa_cvolume *")] pa_cvolume* a, [NativeTypeName("pa_volume_t")] uint b);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sw_volume_divide", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sw_volume_divide", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_volume_t")]
         public static extern uint pa_sw_volume_divide([NativeTypeName("pa_volume_t")] uint a, [NativeTypeName("pa_volume_t")] uint b);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sw_cvolume_divide", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sw_cvolume_divide", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_cvolume *")]
         public static extern pa_cvolume* pa_sw_cvolume_divide([NativeTypeName("pa_cvolume *")] pa_cvolume* dest, [NativeTypeName("const pa_cvolume *")] pa_cvolume* a, [NativeTypeName("const pa_cvolume *")] pa_cvolume* b);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sw_cvolume_divide_scalar", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sw_cvolume_divide_scalar", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_cvolume *")]
         public static extern pa_cvolume* pa_sw_cvolume_divide_scalar([NativeTypeName("pa_cvolume *")] pa_cvolume* dest, [NativeTypeName("const pa_cvolume *")] pa_cvolume* a, [NativeTypeName("pa_volume_t")] uint b);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sw_volume_from_dB", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sw_volume_from_dB", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_volume_t")]
         public static extern uint pa_sw_volume_from_dB(double f);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sw_volume_to_dB", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sw_volume_to_dB", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern double pa_sw_volume_to_dB([NativeTypeName("pa_volume_t")] uint v);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sw_volume_from_linear", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sw_volume_from_linear", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_volume_t")]
         public static extern uint pa_sw_volume_from_linear(double v);
 
-        [DllImport(libraryPath, EntryPoint = "pa_sw_volume_to_linear", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_sw_volume_to_linear", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern double pa_sw_volume_to_linear([NativeTypeName("pa_volume_t")] uint v);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_remap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_remap", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_cvolume *")]
         public static extern pa_cvolume* pa_cvolume_remap([NativeTypeName("pa_cvolume *")] pa_cvolume* v, [NativeTypeName("const pa_channel_map *")] pa_channel_map* from, [NativeTypeName("const pa_channel_map *")] pa_channel_map* to);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_compatible", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_compatible", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_cvolume_compatible([NativeTypeName("const pa_cvolume *")] pa_cvolume* v, [NativeTypeName("const pa_sample_spec *")] pa_sample_spec* ss);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_compatible_with_channel_map", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_compatible_with_channel_map", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern int pa_cvolume_compatible_with_channel_map([NativeTypeName("const pa_cvolume *")] pa_cvolume* v, [NativeTypeName("const pa_channel_map *")] pa_channel_map* cm);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_get_balance", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_get_balance", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern float pa_cvolume_get_balance([NativeTypeName("const pa_cvolume *")] pa_cvolume* v, [NativeTypeName("const pa_channel_map *")] pa_channel_map* map);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_set_balance", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_set_balance", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_cvolume *")]
         public static extern pa_cvolume* pa_cvolume_set_balance([NativeTypeName("pa_cvolume *")] pa_cvolume* v, [NativeTypeName("const pa_channel_map *")] pa_channel_map* map, float new_balance);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_get_fade", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_get_fade", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern float pa_cvolume_get_fade([NativeTypeName("const pa_cvolume *")] pa_cvolume* v, [NativeTypeName("const pa_channel_map *")] pa_channel_map* map);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_set_fade", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_set_fade", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_cvolume *")]
         public static extern pa_cvolume* pa_cvolume_set_fade([NativeTypeName("pa_cvolume *")] pa_cvolume* v, [NativeTypeName("const pa_channel_map *")] pa_channel_map* map, float new_fade);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_get_lfe_balance", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_get_lfe_balance", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern float pa_cvolume_get_lfe_balance([NativeTypeName("const pa_cvolume *")] pa_cvolume* v, [NativeTypeName("const pa_channel_map *")] pa_channel_map* map);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_set_lfe_balance", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_set_lfe_balance", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_cvolume *")]
         public static extern pa_cvolume* pa_cvolume_set_lfe_balance([NativeTypeName("pa_cvolume *")] pa_cvolume* v, [NativeTypeName("const pa_channel_map *")] pa_channel_map* map, float new_balance);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_scale", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_scale", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_cvolume *")]
         public static extern pa_cvolume* pa_cvolume_scale([NativeTypeName("pa_cvolume *")] pa_cvolume* v, [NativeTypeName("pa_volume_t")] uint max);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_scale_mask", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_scale_mask", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_cvolume *")]
         public static extern pa_cvolume* pa_cvolume_scale_mask([NativeTypeName("pa_cvolume *")] pa_cvolume* v, [NativeTypeName("pa_volume_t")] uint max, [NativeTypeName("const pa_channel_map *")] pa_channel_map* cm, [NativeTypeName("pa_channel_position_mask_t")] UIntPtr mask);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_set_position", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_set_position", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_cvolume *")]
         public static extern pa_cvolume* pa_cvolume_set_position([NativeTypeName("pa_cvolume *")] pa_cvolume* cv, [NativeTypeName("const pa_channel_map *")] pa_channel_map* map, [NativeTypeName("pa_channel_position_t")] pa_channel_position t, [NativeTypeName("pa_volume_t")] uint v);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_get_position", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_get_position", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_volume_t")]
         public static extern uint pa_cvolume_get_position([NativeTypeName("pa_cvolume *")] pa_cvolume* cv, [NativeTypeName("const pa_channel_map *")] pa_channel_map* map, [NativeTypeName("pa_channel_position_t")] pa_channel_position t);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_merge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_merge", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_cvolume *")]
         public static extern pa_cvolume* pa_cvolume_merge([NativeTypeName("pa_cvolume *")] pa_cvolume* dest, [NativeTypeName("const pa_cvolume *")] pa_cvolume* a, [NativeTypeName("const pa_cvolume *")] pa_cvolume* b);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_inc_clamp", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_inc_clamp", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_cvolume *")]
         public static extern pa_cvolume* pa_cvolume_inc_clamp([NativeTypeName("pa_cvolume *")] pa_cvolume* v, [NativeTypeName("pa_volume_t")] uint inc, [NativeTypeName("pa_volume_t")] uint limit);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_inc", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_inc", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_cvolume *")]
         public static extern pa_cvolume* pa_cvolume_inc([NativeTypeName("pa_cvolume *")] pa_cvolume* v, [NativeTypeName("pa_volume_t")] uint inc);
 
-        [DllImport(libraryPath, EntryPoint = "pa_cvolume_dec", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport(LibraryPath, EntryPoint = "pa_cvolume_dec", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("pa_cvolume *")]
         public static extern pa_cvolume* pa_cvolume_dec([NativeTypeName("pa_cvolume *")] pa_cvolume* v, [NativeTypeName("pa_volume_t")] uint dec);
     }


### PR DESCRIPTION
This updates the package dependencies to the VS 16.5.0 Preview 1 equivalents and adds the capability for users to hook the DllImportResolver.