### PR TITLE
Ensure GenerateSkipLocalsInit runs before BeforeCompile and ContinuousIntegrationBuild is set in the right place.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,6 +39,7 @@
     <Authors>Tanner Gooding and Contributors</Authors>
     <BaseOutputPath>$(BaseArtifactsPath)bin/$(BaseArtifactsPathSuffix)/</BaseOutputPath>
     <Company>TerraFX</Company>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_RUN_ID)' != ''">true</ContinuousIntegrationBuild>
     <PackageOutputPath>$(BaseArtifactsPath)pkg/$(Configuration)/</PackageOutputPath>
     <Product>TerraFX.Interop.PulseAudio</Product>
     <VersionPrefix>13.0.0</VersionPrefix>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -18,7 +18,6 @@
 
   <!-- Settings that are only set for CI builds -->
   <PropertyGroup Condition="'$(GITHUB_RUN_ID)' != ''">
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <PackageVersion Condition="'$(EXCLUDE_RUN_ID_FROM_PACKAGE)' == ''">$(Version)-$(GITHUB_RUN_ID)</PackageVersion>
   </PropertyGroup>
 

--- a/sources/Directory.Build.targets
+++ b/sources/Directory.Build.targets
@@ -35,7 +35,7 @@
   </PropertyGroup>
 
   <Target Name="GenerateSkipLocalsInit"
-          BeforeTargets="CoreCompile"
+          BeforeTargets="BeforeCompile;CoreCompile"
           DependsOnTargets="PrepareForBuild"
           Condition="'$(Language)' == 'C#'"
           Inputs="$(MSBuildAllProjects)"


### PR DESCRIPTION
This ensures packages pass https://github.com/NuGetPackageExplorer/NuGetPackageExplorer